### PR TITLE
fix: server dockerfile 빌드 오류 수정

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -61,7 +61,7 @@ COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
 COPY apps/server/package.json ./apps/server/
 
 # Install production dependencies only
-RUN pnpm install --frozen-lockfile --prod
+RUN pnpm install --frozen-lockfile --prod --ignore-scripts
 
 # Copy built files from build stage
 COPY --from=build /app/apps/server/dist ./apps/server/dist


### PR DESCRIPTION
### ☑️ 변경 사항

server dockerfile에서 `pnpm install`을 수행하는 과정에서 husky를 실행하는데 이를 찾을 수 없어서 에러가 발생했습니다. 프로덕션 이미지 빌드 시 husky는 필요없는 것 같아서 `--ignore-scripts` 옵션을 사용하여 문제를 해결했습니다.