### PR TITLE
fix: ssh-action 버전 오타 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,7 +47,7 @@ jobs:
 
       # docker hub 계정이 다른데 협업 기능은 유료이므로 두 번에 걸쳐서 이미지를 가져와야함.
       - name: Deploy with Docker Compose
-        uses: appleboy/ssh-action@1.2.4
+        uses: appleboy/ssh-action@v1.2.4
         env:
           IMAGE_TAG: ${{ inputs.image_tag }}
           DOCKERHUB_WEB_USERNAME: ${{ secrets.DOCKERHUB_WEB_USERNAME }}


### PR DESCRIPTION
`appleboy/ssh-action` 액션의 버전에 v 프리픽스가 안 붙어있어서 문제가 발생해서 오타를 고쳤습니다..!