### PR TITLE
hotfix: 프론트엔드 개발 서버 경로 에러 핫픽스

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -22,6 +22,7 @@ RUN pnpm install --frozen-lockfile
 FROM base AS build
 
 ENV CI=true
+ENV DOCKER_BUILD=true
 
 # [수정] 빌드에 필요한 모든 소스 코드를 루트 기준으로 복사합니다.
 # 터보팩은 프로젝트 전체 구조를 참조해야 하므로 앱 코드만 복사하면 안 됩니다.

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -5,7 +5,11 @@ import type { NextConfig } from 'next'
 const nextConfig: NextConfig = {
   output: 'standalone',
   reactCompiler: true,
-  outputFileTracingRoot: path.join(__dirname, '../../'),
+  // Docker 빌드 시에만 outputFileTracingRoot 적용하여 모노레포 구조 유지
+  // 로컬 개발 환경에서는 제외하여 tailwindcss 해석 문제 방지
+  ...(process.env.DOCKER_BUILD === 'true' && {
+    outputFileTracingRoot: path.join(__dirname, '../../'),
+  }),
 }
 
 export default nextConfig


### PR DESCRIPTION
- apps/web/Dockerfile: 환경변수 DOCKER_BUILD추가
- apps/web/next.config.ts: 조건부 outputTracingRoot 변수 조건부 설정

## 작업 내용

- web 프로젝트에서 pnpm dev로 개발 서버 가동 시 tailwindcss 라이브러리를 찾지 못하는 문제 수정
- 컨테이너 빌드를 위한 next.config.ts파일의 outputTraceRoot설정이 개발 서버 가동시에도 활용되어 의존 라이브러리를 찾지 못함
- build 조건일 때만 모노레포의 루트 경로를 사용하도록 ENV=DOCKER_BUILD boolean값 추가
- next.config.ts 파일도 조건부 변수를 추가

